### PR TITLE
v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## unreleased
+- WiFiセットアップ時にユーザーへ接続先WiFiのSSIDをアナウンス
+- APモードの時もSSIDを表示
 ## v0.0.3
 - GitHubActionのリリースではPreReleseとして公開する
 - バージョン表示のバグを修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - WiFiセットアップ時にユーザーへ接続先WiFiのSSIDをアナウンス
 - APモードの時もSSIDを表示
 - WiFiセットアップ機能が無効の場合にメニューにWiFiのメニューを表示しない
+- 表示関連のエラーを修正(casaos:system:utilization)
 
 ## v0.0.3
 - GitHubActionのリリースではPreReleseとして公開する

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## unreleased
 - WiFiセットアップ時にユーザーへ接続先WiFiのSSIDをアナウンス
 - APモードの時もSSIDを表示
+- WiFiセットアップ機能が無効の場合にメニューにWiFiのメニューを表示しない
+
 ## v0.0.3
 - GitHubActionのリリースではPreReleseとして公開する
 - バージョン表示のバグを修正

--- a/src/assets/lang/ja_JP.json
+++ b/src/assets/lang/ja_JP.json
@@ -412,7 +412,7 @@
   "launch-and-open": "起動して開く",
   "WifiSettings": "WiFi設定",
   "WifiCurrentStatus": "現在の状態",
-  "WifiApplayMessage": "🔄 Wi-Fi設定を適用中です。接続が一時的に切れることがあります。",
+  "WifiApplayMessage": "🔄 Wi-Fi設定を適用中です。",
   "WifiMode": "モード",
   "WifiModeAccessPoint": "アクセスポイント",
   "WifiModeClient": "WiFi接続中",

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -282,7 +282,7 @@
 					</div>
 					<!-- Automount USB Drive End  -->
 					<!-- WiFi Settings Start -->
-					<div class="_is-large hover-effect _is-radius pr-2 mr-4 ml-4">
+					<div class="_is-large hover-effect _is-radius pr-2 mr-4 ml-4" v-if="enableWifiSetup">
 						<div class="is-flex is-align-items-center">
 							<div class="is-flex is-align-items-center is-flex-grow-1 _is-normal">
 								<b-icon class="mr-1 ml-1" icon="wifi" pack="mdi" custom-size="20px" ></b-icon>
@@ -465,6 +465,7 @@ export default {
 			showPower: false,
 			showPowerTitle: "",
 			showPowerMessage: "",
+			enableWifiSetup: false,
 		};
 	},
 	props: {
@@ -556,6 +557,7 @@ export default {
 		this.getUserInfo();
 		this.getUsbStatus();
 		this.getHardwareInfo();
+		this.getOptionInfo();
 	},
 
 	methods: {
@@ -768,6 +770,13 @@ export default {
 				props: {
 					changeLog: this.updateInfo.version.change_log,
 				},
+			});
+		},
+		getOptionInfo() {
+			console.log("****getOptionInfo")
+			this.$api.option.getOptionStatus().then((res) => {
+				this.enableWifiSetup = res.data;
+				console.log(res.data)
 			});
 		},
 		/*************************************************

--- a/src/service/api.js
+++ b/src/service/api.js
@@ -15,6 +15,7 @@ import local_storage from "./local_storage.js";
 import driver from './driver.js';
 import cloud from './cloud.js';
 import wifi from './wifi.js';
+import option from './option.js';
 
 export default {
 	// Apps
@@ -38,5 +39,6 @@ export default {
 	// User
 	users,
 	local_storage,
-	wifi
+	wifi,
+	option
 }

--- a/src/service/option.js
+++ b/src/service/option.js
@@ -1,0 +1,9 @@
+import {api} from "./service.js";
+
+const PREFIX = "/v2/casaos";
+const option = {
+	getOptionStatus() {
+		return api.get(`${PREFIX}/option`);
+	},
+}
+export default option;

--- a/src/service/wifi.js
+++ b/src/service/wifi.js
@@ -10,6 +10,9 @@ const wifi = {
 	},
 	setupAP(){
 		return api.post(`${PREFIX}/wifi/ap-mode`);
+	},
+	getWifiAPSSID() {
+		return api.get(`${PREFIX}/wifi/ap-ssid`);
 	}
 }
 export default wifi;

--- a/src/widgets/Disks.vue
+++ b/src/widgets/Disks.vue
@@ -122,9 +122,9 @@ export default {
 		"casaos:system:utilization"(res) {
 			let data = res.Properties
 			// DISK
-			this.getDiskInfo(JSON.parse(data.sys_disk))
+			//this.getDiskInfo(JSON.parse(data.sys_disk))
 			// USB
-			this.usbDisks = JSON.parse(data.sys_usb)
+			//this.usbDisks = JSON.parse(data.sys_usb)
 		}
 	}
 }


### PR DESCRIPTION
- WiFiセットアップ時にユーザーへ接続先WiFiのSSIDをアナウンス
- APモードの時もSSIDを表示
- WiFiセットアップ機能が無効の場合にメニューにWiFiのメニューを表示しない
- 表示関連のエラーを修正(casaos:system:utilization)
